### PR TITLE
fefactor: add dynamic disk /nix volume growth

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        hatchet-protocol: [holster, cleave, rampage]
+        hatchet-protocol: [holster, carve, cleave, rampage]
       fail-fast: false
     permissions:
       contents: read
@@ -28,3 +28,28 @@ jobs:
         run: |
           nix --version
           echo "Hello Nix" | nix run "https://flakehub.com/f/NixOS/nixpkgs/*#neo-cowsay"
+      - name: Status
+        run: |
+          if [ -f ${HOME}/.expansion/expansion.log ]; then
+            cat ${HOME}/.expansion/expansion.log
+          fi
+          ls -ltr ${HOME}/.expansion/*_done
+          all_disks=()
+  
+          # Check for disks in /mnt directory
+          mnt_disks=(/mnt/disk*.img)
+          if [[ -e "${mnt_disks[0]}" ]]; then
+            all_disks+=("${mnt_disks[@]}")
+          fi
+
+          # Check for disks in / directory
+          root_disks=(/disk*.img)
+          if [[ -e "${root_disks[0]}" ]]; then
+            all_disks+=("${root_disks[@]}")
+          fi        
+          
+          echo "Found ${#all_disks[@]} disk image(s):"
+          for disk in "${all_disks[@]}"; do
+            echo "- $disk ($(du -h "$disk" | cut -f1))"
+          done
+          

--- a/README.md
+++ b/README.md
@@ -1,48 +1,11 @@
-# Nothing but Nix ❄️
-**Slash the bloat. Maximize the space. Run [Nix](https://zero-to-nix.com/concepts/nix/) with confidence on GitHub Actions.**
-- Adapted from <https://github.com/lucasew/action-i-only-care-about-nix>.
+# Nothing but Nix
 
-## What does it do?
+**Transform your GitHub Actions runner into a [Nix](https://zero-to-nix.com/concepts/nix/) ❄️ powerhouse by ruthlessly slashing pre-installed bloat.**
 
-This action **brutally purges** unnecessary software from GitHub Actions runners to create a large volume for the `/nix` store:
+GitHub Actions runners come with meager disk space for Nix - a mere ~20GB.
+*Nothing but Nix* **brutally purges** unnecessary software, giving you **65GB to 130GB** for your Nix store! 💪
 
-- ️🌨️ **Creates a dedicated `/nix` volume** by merging free space from multiple partitions into one large, optimized filesystem
-  - On the standard free-tier GitHub runner the **`/nix` volume will be 85GB to 130GB** ✨ depending on the *Hatchet Protocol* selected
-- ️🗑️ **Reclaim Gigabytes** of disk space by removing language runtimes, Docker images, package managers, libraries and more...
-- ⚡ **Lightning-fast cleanup** using `rmz`, a high-performance alternative to `rm` that dramatically reduces preparation time
-
-### About `rmz`
-
-Under the hood, *Nothing but Nix* utilizes `rmz` from the [Fast Unix Commands (FUC)](https://github.com/SUPERCILEX/fuc) project, which:
-
-- Delivers **significantly faster** file removal operations than standard `rm`
-- Uses a smart scheduling algorithm that optimizes directory deletion through atomic reference counting
-- Makes file cleanup operations run in parallel where possible
-- Helps *Nothing but Nix* **reclaim disk space in seconds rather than minutes**
-
-## Why do I need *Nothing but Nix*
-
-GitHub Actions runners come packed with pre-installed tools you'll likely never use in your Nix workflow. 
-The **typical space available in a standard GitHub runner for `/nix` is 20GB**. We deserve better 😁
-This action:
-
-- 🗄️ **Makes a large `/nix` volume** that prevents *"no space left on device"* errors during Nix builds
-- ️⏱️ **Saves precious CI time** with optimised file removal operations when compared to similar GitHub actions
-
-```
-Filesystem      Size  Used Avail Use% Mounted on
-/dev/root        72G  5.6G   67G   8% /
-tmpfs           7.9G   84K  7.9G   1% /dev/shm
-tmpfs           3.2G  1.1M  3.2G   1% /run
-tmpfs           5.0M     0  5.0M   0% /run/lock
-/dev/sdb16      881M   60M  760M   8% /boot
-/dev/sdb15      105M  6.2M   99M   6% /boot/efi
-/dev/sda1        74G  4.1G   66G   6% /mnt
-tmpfs           1.6G   12K  1.6G   1% /run/user/1001
-/dev/loop0      130G  5.7M  129G   1% /nix
-```
-
-## How to use it
+## Usage
 
 Add this action **before** installing Nix in your workflow:
 
@@ -58,41 +21,89 @@ jobs:
       - uses: wimpysworld/nothing-but-nix@main
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          determinate: true
       - name: Run Nix
         run: |
           nix --version
           # Your Nix-powered steps here...
 ```
 
-### Hatchet Protocol 🪓
+## The Problem: Making Room for Nix to Thrive 🌱
 
-You can control the file purging aggression using the `hatchet-protocol` input:
+Standard GitHub Actions runners are stuffed with *"bloatware"* you'll never use in a Nix workflow:
+
+- 🌍 Web browsers. Lots of them. Gotta have 'em all!
+- 🐳 Docker images consuming gigabytes of precious disk space
+- 💻 Unnecessary language runtimes (.NET, Ruby, PHP, Java...)
+- 📦 Package managers gathering digital dust
+- 📚 Documentation no one will ever read
+
+This bloat leaves only ~20GB for your Nix store - barely enough for serious Nix builds! 😞
+
+## The Solution: Nothing but Nix ️❄️
+
+**Nothing but Nix** takes a scorched-earth approach to GitHub Actions runners and mercilessly reclaims disk space using a two-phase attack:
+
+1. **Initial Slash:** Instantly creates a large `/nix` volume (~65GB) by claiming free space from `/mnt`
+2. **Background Rampage:** While your workflow continues, we ruthlessly eliminate unnecessary software to expand your `/nix` volume up to ~130GB
+   - Web browsers? Nope ⛔
+   - Docker images? Gone 🗑️
+   - Language runtimes? Obliterated 💥
+   - Package managers? Annihilated 💣
+   - Documentation? Vaporized ️👻
+
+The file system purge is powered by `rmz` (from the [Fast Unix Commands (FUC)](https://github.com/SUPERCILEX/fuc) project) - a high-performance alternative to `rm` that makes space reclamation blazing fast! ⚡
+   - Outperforms standard `rm` by an order of magnitude
+   - Parallel-processes deletions for maximum efficiency
+   - **Reclaims disk space in seconds rather than minutes!** ️⏱️
+
+The end result? A GitHub Actions runner with **65GB to 130GB** of Nix-ready space! 😁
+
+### Dynamic Volume Growth
+
+Unlike other solutions, **Nothing but Nix** grows your `/nix` volume dynamically:
+
+1. **Initial Volume Creation (~1 second):**
+   - Creates a loop device from free space on `/mnt`
+   - Sets up a BTRFS filesystem in RAID0 configuration
+   - Mounts with compression and performance tuning
+   - Provides an 65GB `/nix` immediately, even before the purge begins
+
+2. **Background Expansion (30-60 seconds):**
+   - Executes purging operations based on your selected *Hatchet Protocol*
+   - Monitors for newly freed space as bloat is eliminated
+   - Dynamically adds an expansion disk to the `/nix` volume
+   - Rebalances the filesystem to incorporate new space
+
+The `/nix` volume automatically **grows during workflow execution** 🎩🪄
+
+### Choose Your Weapon: The Hatchet Protocol 🪓
+
+Control the level of annihilation 💥 with the `hatchet-protocol` input:
 
 ```yaml
 - uses: wimpysworld/nothing-but-nix@main
   with:
-    hatchet-protocol: 'cleave'  # Options: holster, cleave (default), rampage
+    hatchet-protocol: 'cleave'  # Options: holster, carve, cleave (default), rampage
 ```
 
 #### Protocol Comparison
 
-| Name    | Description                                     | Cleanse apt | Cleanse docker | Cleanse snap | Filesystems purged  | Preparation time | `/nix` |
-|---------|-------------------------------------------------|-------------|----------------|--------------|---------------------|------------------|--------|
-| Holster | Keeps the hatchet sheathed, just combines space | No          | No             | No           | No                  | 1 second         | ~85GB  |
-| Cleave  | Makes powerful, decisive cuts to large packages | Minimal     | Yes            | No           | /opt and /usr/local | ~30 seconds      | ~120GB |
-| Rampage | Relentless, brutal elimination of all bloat     | Aggressive  | Yes            | Yes          | Muahahaha!          | ~60 seconds      | ~130GB |
+| Protocol | `/nix` | Description                                      | Cleanse apt | Cleanse docker | Cleanse snap | Filesystems purged      |
+|----------|--------|--------------------------------------------------|-------------|----------------|--------------|-------------------------|
+| Holster  | ~65GB  | Keep the hatchet sheathed, use space from `/mnt` | No          | No             | No           | No                      |
+| Carve    | ~85GB  | Craft and combine free space from `/` and `/mnt` | No          | No             | No           | No                      |
+| Cleave   | ~120GB | Make powerful, decisive cuts to large packages   | Minimal     | Yes            | No           | `/opt` and `/usr/local` |
+| Rampage  | ~130GB | Relentless, brutal elimination of all bloat      | Aggressive  | Yes            | Yes          | Muahahaha! 🔥🌎         |
 
-*The sizes of `/nix` quoted above are based on the standard free-tier GitHub runners.*
-
-- **Holster** when you need to optimise for reduced CI runtime
-- **Cleave** (default) for a good balance of CI runtime space and preservation of functional underlying tools.
-- **Rampage** when you need the absolute maximum Nix store space and don't care how damaged the pre-installed tools become `#nix-is-life`
+Choose wisely:
+- **Holster** when you need the runner's tools to remain fully functional
+- **Carve** preserve functional runner tooling but claim all free space for Nix
+- **Cleave** (default) for a good balance of space and functionality
+- **Rampage** when you need maximum Nix space and don't care what breaks `#nix-is-life`
 
 ## Requirements
 
 - Only supports **Ubuntu** GitHub Actions runners
 - Must run **before** Nix is installed
 
-Now go build something amazing with all that extra space! ❄️
+Now go build something amazing with all that glorious Nix space! ❄️

--- a/action.yml
+++ b/action.yml
@@ -37,22 +37,27 @@ runs:
         # Convert to lowercase for case-insensitive comparison
         input_protocol="${input_protocol,,}"
         
-        # Default to Cleave (1)
-        protocol_level=1
-        
-        if [[ "$input_protocol" == "holster" ]]; then
-          protocol_level=0
-          echo "🪓 Hatchet Protocol: Holster - Keeping the hatchet sheathed, just combining space (Level 0)"
-        elif [[ "$input_protocol" == "rampage" ]]; then
-          protocol_level=2
-          echo "🪓 Hatchet Protocol: Rampage - Relentless, brutal elimination of all bloat (Level 2)"
-        else
-          echo "🪓 Hatchet Protocol: Cleave - Making powerful, decisive cuts to bloated packages (Level 1)"
-        fi
-        
+        case "$input_protocol" in
+          "holster")
+            echo "🪓 Hatchet Protocol: Holster - Keep the hatchet sheathed, use space from /mnt (Level 0)"
+            protocol_level=0;;
+          "carve")
+            echo "🪓 Hatchet Protocol: Carve - Craft and combine free space from / and /mnt (Level 1)"
+            protocol_level=1;;
+          "cleave")
+            echo "🪓 Hatchet Protocol: Cleave - Make powerful, decisive cuts to large packages (Level 2)"
+            protocol_level=2;;
+          "rampage")
+            echo "🪓 Hatchet Protocol: Rampage - Relentless, brutal elimination of all bloat (Level 3)"
+            protocol_level=3;;
+          *)
+            echo "🪓 Hatchet Protocol: Cleave - Make powerful, decisive cuts to large packages (Level 2)"
+            protocol_level=2;;
+        esac
+
         echo "level=${protocol_level}" >> $GITHUB_OUTPUT
     - name: The Setup
-      if: steps.environment-check.outputs.is_supported == 'true' && steps.set-hatchet-protocol.outputs.level > 0
+      if: steps.environment-check.outputs.is_supported == 'true' && steps.set-hatchet-protocol.outputs.level > 1
       shell: bash
       run: |
         ARCH=$(uname -m)          
@@ -80,62 +85,130 @@ runs:
         chmod +x rmz
         sudo mv rmz /usr/bin/rmz
         rmz --version
-    - name: Cleanse apt
+    - name: The Volume
       if: steps.environment-check.outputs.is_supported == 'true'
       shell: bash
       run: |
-        sudo tee /etc/dpkg/dpkg.cfg.d/01_nocruft > /dev/null << 'EOF'
+        # Create initial loop device using Holster approach (minimal space reclamation)
+        
+        free_space=$(df -m --output=avail /mnt | tail -n 1 | tr -d ' ')
+        echo "Initial free space of /mnt: ${free_space}MB"
+        loop_dev=$(sudo losetup --find)
+        loop_num=${loop_dev##*/loop}        
+        if sudo fallocate -l $((free_space - 1024))M "/mnt/disk${loop_num}.img"; then  
+          sudo losetup ${loop_dev} "/mnt/disk${loop_num}.img"
+        fi
+          
+        # Create filesystem
+        sudo mkfs.btrfs -L nix -d raid0 -m raid0 --nodiscard "${loop_dev}"
+        sudo btrfs device scan
+        sudo btrfs filesystem show
+
+        # Mount filesystem
+        sudo mkdir -p /nix
+        sudo mount LABEL=nix /nix -o noatime,nobarrier,compress=zstd:1,space_cache=v2,commit=120
+        sudo df -h
+        
+        # Create a directory to store expansion state
+        mkdir -p "${HOME}/.expansion"
+        echo "Initial volume created" > "${HOME}/.expansion/holster_done"
+    - name: The Purge
+      if: steps.environment-check.outputs.is_supported == 'true'
+      shell: bash
+      run: |
+        cat > /tmp/expand_nix_volume.sh << 'EOF'
+        #!/bin/bash
+        set -e
+        
+        protocol_level="${{ steps.set-hatchet-protocol.outputs.level }}"
+        expansion_dir="${HOME}/.expansion"
+        
+        function add_expansion_disk() {
+          # Check for additional free space after purging
+          free_space=$(df -m --output=avail / | tail -n 1 | tr -d ' ')
+          echo "Free space of / after purge: ${free_space}MB"
+
+          # Create additional disk if at least 4GB free space exists
+          if [ $free_space -gt 4096 ]; then
+            # Calculate the size of the expansion disk, reserving 2GB
+            disk_size=$((free_space - 2048))
+            echo "Creating expansion disk of ${disk_size}MB in /"
+            # Create expansion disk image
+            loop_dev=$(sudo losetup --find)
+            loop_num=${loop_dev##*/loop}
+            if sudo fallocate -l ${disk_size}M "/disk${loop_num}.img"; then
+              sudo losetup ${loop_dev} "/disk${loop_num}.img"
+              
+              # Add the new device to the pool
+              sudo btrfs device add ${loop_dev} /nix
+              echo "Added expansion disk "/disk${loop_num}.img" (${loop_dev}, ${disk_size}MB) to /nix pool" > $expansion_dir/expansion_done
+              
+              # Balance the filesystem to use the new space
+              sudo btrfs balance start -dusage=50 /nix
+              sudo btrfs filesystem show
+              sudo df -h
+            fi
+          fi
+        }
+
+        # If carve is selected, claim space from / now
+        if [[ "$protocol_level" -eq 1 ]]; then
+          echo "Disk space has been carved out" > $expansion_dir/carve_done
+          add_expansion_disk
+        fi
+
+        # Cleanse apt
+        if [[ "$protocol_level" -ge 2 ]]; then
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nocruft > /dev/null << 'APTCFG'
         path-exclude /usr/share/doc/*
         path-exclude /usr/share/fonts/*
         path-exclude /usr/share/icons/*
         path-exclude /usr/share/info/*
         path-exclude /usr/share/man/*
-        EOF
+        APTCFG
 
-        protocol_level="${{ steps.set-hatchet-protocol.outputs.level }}"
-        if [[ "$protocol_level" -ge 2 ]]; then
-          sudo apt-get -y remove --purge \
-            azure-cli \
-            firefox \
-            google-chrome-stable \
-            google-cloud-sdk \
-            microsoft-edge-stable \
-            powershell
-          sudo apt-get -y autoremove --purge
-        fi
+          if [[ "$protocol_level" -ge 3 ]]; then
+            sudo apt-get -y remove --purge \
+              azure-cli \
+              firefox \
+              google-chrome-stable \
+              google-cloud-sdk \
+              microsoft-edge-stable \
+              powershell
+            sudo apt-get -y autoremove --purge
+          fi
 
-        if [[ "$protocol_level" -ge 1 ]]; then
           sudo apt-get -y clean
+          echo "Cleanse apt complete" > $expansion_dir/apt_done
         fi
-    - name: Cleanse docker
-      if: steps.environment-check.outputs.is_supported == 'true' && steps.set-hatchet-protocol.outputs.level >= 1
-      shell: bash
-      run: |
-        for CRUFT in $(docker image ls --format '{{.ID}}'); do
-          docker rmi --force "${CRUFT}" || true
-        done
-        docker system prune --all --force
-    - name: Cleanse snap
-      if: steps.environment-check.outputs.is_supported == 'true' && steps.set-hatchet-protocol.outputs.level >= 2
-      shell: bash
-      run: |
-        sudo systemctl stop snapd.service || true
-        sudo systemctl disable snapd.service || true
-        sudo systemctl mask snapd.service || true
-        sudo umount --recursive /snap/*/* || true
-        sudo rmz -f \
-          /snap \
-          /usr/bin/snap* \
-          /usr/lib/snapd \
-          /var/snap \
-          /var/lib/snapd \
-          "${HOME}/snap"
-    - name: The Purge
-      if: steps.environment-check.outputs.is_supported == 'true'
-      shell: bash
-      run: |
-        protocol_level="${{ steps.set-hatchet-protocol.outputs.level }}"
-        if [[ "$protocol_level" -ge 1 ]]; then
+        
+        # Cleanse docker
+        if [[ "$protocol_level" -ge 2 ]]; then
+          for CRUFT in $(docker image ls --format '{{.ID}}'); do
+            docker rmi --force "${CRUFT}" || true
+          done
+          docker system prune --all --force
+          echo "Cleanse docker complete" > $expansion_dir/docker_done
+        fi
+        
+        # Cleanse snap
+        if [[ "$protocol_level" -ge 3 ]]; then
+          sudo systemctl stop snapd.service || true
+          sudo systemctl disable snapd.service || true
+          sudo systemctl mask snapd.service || true
+          sudo umount --recursive /snap/*/* || true
+          sudo rmz -f \
+            /snap \
+            /usr/bin/snap* \
+            /usr/lib/snapd \
+            /var/snap \
+            /var/lib/snapd \
+            "${HOME}/snap"
+          echo "Cleanse snap complete" > $expansion_dir/snap_done
+        fi
+        
+        # Cleave
+        if [[ "$protocol_level" -ge 2 ]]; then
           sudo rmz -f \
             "${HOME}/.rustup" \
             "${HOME}/.cargo" \
@@ -148,9 +221,11 @@ runs:
             /opt/google \
             /opt/mssql-tools
           sudo mkdir -p /usr/local/{bin,doc,include,lib,man,sbin,share,src}
+          echo "Cleave complete" > $expansion_dir/cleave_done
         fi
-
-        if [[ "$protocol_level" -ge 2 ]]; then
+        
+        # Rampage
+        if [[ "$protocol_level" -ge 3 ]]; then
           sudo rmz -f \
             /usr/bin/buildah \
             /usr/bin/docker* \
@@ -224,30 +299,22 @@ runs:
             /var/lib/podman \
             /var/lib/postgresql \
             /var/lib/ubuntu-advantage
+          echo "Rampage complete" > $expansion_dir/rampage_done
         fi
-    - name: The Disks
-      if: steps.environment-check.outputs.is_supported == 'true'
-      shell: bash
-      run: |
-        # Create loop devices
-        loops=()
-        for ROOT in / /mnt/; do
-          free_space=$(df -m --output=avail "${ROOT}" | tail -n 1 | tr -d ' ')
-          echo "Free space of "${ROOT}": ${free_space}MB"
-          if sudo fallocate -l $((free_space - 1024))M "${ROOT}"disk.img; then
-            loop_dev=$(sudo losetup --find)
-            sudo losetup ${loop_dev} "${ROOT}"disk.img
-            loops+=(${loop_dev})
-          fi
-        done
-          
-        # Create filesystem
-        sudo mkfs.btrfs -L nix -d raid0 -m raid0 "${loops[@]}"
-        sudo btrfs device scan
-        sudo btrfs filesystem show
 
-        # Mount filesystem
-        sudo mkdir -p /nix
-        sudo mount LABEL=nix /nix -o noatime,nobarrier,compress=zstd:1,space_cache=v2,ssd,commit=120,discard=async
-        sudo df -h
+        # Claim the space from / for purging
+        if [[ "$protocol_level" -ge 2 ]]; then
+          echo "The Purge Is Complete!" > $expansion_dir/purge_done
+          add_expansion_disk
+        fi
+        EOF
+
+        # Make script executable and run in background
+        chmod +x /tmp/expand_nix_volume.sh
+        /tmp/expand_nix_volume.sh > ${HOME}/.expansion/expansion.log 2>&1 &
+        echo "📈 Background space expansion started. /nix will grow as space becomes available."
         
+        # Wait for the expand_nix_volume.sh process to finish
+        while wait -n; do
+          sleep 0.5
+        done


### PR DESCRIPTION
This change significantly refactors how disk space is managed within the GitHub Action, utilising btrfs on loop devices to create an expandable /nix volume and implementing a background process to expand the volume dynamically using freed space.

Disk space reclamation is now done in a background process allowing the main action to complete faster.

Implements the 'carve' hatchet protocol that reclaims disk space from both the root partition and /mnt to expand the nix volume. This protocol provides a balance between preserving runner tooling and maximising Nix space.

The initial volume creation claims free space from /mnt only. Space from / is claimed after the initial volume setup if "carve" or higher is selected.
