### PR TITLE
fix: set TMPDIR to /nix/_temp to resolve build space issues. fixes #18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,8 @@ jobs:
         run: |
           nix --version
           echo "Hello Nix" | nix run "https://flakehub.com/f/NixOS/nixpkgs/*#neo-cowsay"
+          # Build a package to ensure the Nix store is functional
+          nix build "https://flakehub.com/f/NixOS/nixpkgs/*#hello"
   nix-quick-install:
     name: nix-quick-action on ${{ matrix.os }} with ${{ matrix.hatchet-protocol }}
     runs-on: ${{ matrix.os }}
@@ -59,4 +61,6 @@ jobs:
         run: |
           nix --version
           echo "Hello Nix" | nix run "nixpkgs#neo-cowsay"
+          # Build a package to ensure the Nix store is functional
+          nix build "nixpkgs#hello"
           

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,12 @@ runs:
         sudo mount LABEL=nix /nix -o noatime,nobarrier,nodiscard,compress=zstd:1,space_cache=v2,commit=120
         sudo df -h
 
+        # Create a tmp directory within /nix for Nix builds and set TMPDIR
+        sudo mkdir -p /nix/_temp
+        sudo chmod 1777 /nix/_temp
+        echo "TMPDIR=/nix/_temp" >> $GITHUB_ENV
+        echo "Set TMPDIR=/nix/_temp to use space on the /nix volume for builds."
+
         # Create a directory to store expansion state
         mkdir -p "${HOME}/.expansion"
         echo "Initial volume created" | tee "${HOME}/.expansion/holster_done"
@@ -363,4 +369,7 @@ runs:
           for disk in "${all_disks[@]}"; do
             echo "- $disk ($(du -h "$disk" | cut -f1))"
           done
+          echo "Space used by TMPDIR:"
+          sudo du -csh "$TMPDIR" || true
+          echo "Space used by disk images:"
           sudo df -h


### PR DESCRIPTION
This change addresses an issue where Nix builds could fail due to insufficient space in the default temporary build directory (e.g., /home/runner/work/_temp or /build), even when a large /nix volume was available.

The fix involves:
1. Creating a dedicated temporary directory at /nix/_temp within the BTRFS volume managed by this action.
2. Setting the TMPDIR environment variable to /nix/_temp using $GITHUB_ENV. This makes the change effective for all subsequent steps in the GitHub Actions job, including Nix installation and Nix build processes.

Rationale:
This approach was chosen because it transparently resolves the issue for users without requiring any changes to their workflows or new action inputs. By redirecting TMPDIR, Nix and other tools that respect this standard environment variable will automatically use the more spacious /nix volume for their temporary files, preventing "no space left on device" errors during builds.

Alternatives Considered and Rejected:

1.  Bind-mounting system temporary directories (e.g., /tmp) to a location within /nix:
    -   Rejected due to increased complexity and potential for unintended
        side effects on other system processes or tools that might have
        specific expectations for the original temporary directories.

2.  Modifying nix.conf to set 'build-dir':
    -   Rejected because this action runs *before* Nix is typically
        installed. Modifying Nix configuration files would require
        knowledge of the Nix installation path and timing, making the
        solution less robust and more coupled to specific Nix installer
        actions. It also wouldn't be transparent.

3.  Requiring users to manually increase 'root-safe-haven':
    -   Rejected as it doesn't directly address the TMPDIR location and
        places the burden of configuration on the user. The goal was a
        solution that "just works."

This fix ensures that the significant disk space reclaimed by "Nothing but Nix" is effectively utilized not only for the Nix store but also for the temporary build artifacts generated during Nix package construction.