### PR TITLE
feat: add nix-permission-edict input for user ownership of /nix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
         with:
           hatchet-protocol: ${{ matrix.hatchet-protocol }}
           witness-carnage: true
+          nix-permission-edict: true
       - uses: nixbuild/nix-quick-install-action@v30
       - name: Nix
         run: |

--- a/README.md
+++ b/README.md
@@ -135,4 +135,16 @@ These safe havens define how much space (in MB) will be mercifully spared during
 
 Increase these values if you need more breathing room on your filesystems, or decrease them to show no mercy! 😈
 
+### Grant User Ownership of /nix (Nix Permission Edict) 🧑‍⚖️
+
+Some Nix installers or configurations expect the `/nix` directory to be writable by the current user. By default, `/nix` is owned by root. If you need user ownership (e.g., for certain Nix installer scripts that don't use `sudo` for all operations within `/nix`), you can enable the `nix-permission-edict`:
+
+```yaml
+- uses: wimpysworld/nothing-but-nix@main
+  with:
+    nix-permission-edict: true  # Default: false
+```
+
+When `nix-permission-edict` is set to `true`, the action will run `sudo chown -R "$(id --user)":"$(id --group)" /nix` after mounting `/nix`.
+
 Now go and build something amazing with all that glorious Nix store space! ❄️

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Space in MB to mercifully spare on the /mnt filesystem (default: 1024)'
     required: false
     default: '1024'
+  nix-permission-edict:
+    description: 'Grant user ownership of /nix directory (default: false). Useful for Nix installers that require user-writable /nix.'
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -129,6 +133,11 @@ runs:
         sudo mkdir -p /nix
         sudo mount LABEL=nix /nix -o noatime,nobarrier,nodiscard,compress=zstd:1,space_cache=v2,commit=120
         sudo df -h
+
+        if [[ "${{ inputs.nix-permission-edict }}" == "true" ]]; then
+          echo "Applying Nix Permission Edict: Granting user ownership of /nix"
+          sudo chown -R "$(id --user)":"$(id --group)" /nix
+        fi
 
         # Create a tmp directory within /nix for Nix builds and set TMPDIR
         sudo mkdir -p /nix/_temp


### PR DESCRIPTION
This commit introduces a new optional input `nix-permission-edict` (default: false) to the action.

When `nix-permission-edict` is set to `true`, the action will execute `sudo chown -R "$(id --user)":"$(id --group)" /nix` after the /nix volume is mounted.

This feature provides flexibility for Nix installers or specific Nix configurations that require the /nix directory to be writable by the current GitHub Actions runner user, rather than being owned by root. Most Nix installers handle permissions appropriately with sudo, but this option caters to scenarios where direct user ownership is necessary or preferred.

The README.md has been updated to document this new input, and the test workflow for `nix-quick-install` has been updated to utilise this new option.

- Fixes #16