### PR TITLE
POSIX-compliant lowercase

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
       run: |
         input_protocol="${{ inputs.hatchet-protocol }}"
         # Convert to lowercase for case-insensitive comparison
-        input_protocol="${input_protocol,,}"
+        input_protocol="$(tr '[:upper:]' '[:lower:]' <<< "$input_protocol")"
         
         case "$input_protocol" in
           "holster")


### PR DESCRIPTION
This error is reported on Darwin runners which presumably have ZSH, not Bash.

Resolves https://github.com/wimpysworld/nothing-but-nix/issues/28