### PR TITLE
post action ls fail safe

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -359,7 +359,7 @@ runs:
       with:
         shell: bash -e {0}
         post-run: |
-          ls -ltr ${HOME}/.expansion/*_done
+          ls -ltr ${HOME}/.expansion/*_done || true
           all_disks=()
   
           # Check for disks in /mnt directory


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/37835bd6-8db1-4186-8436-7dff8ff793af)

post action wants to display non existing files and crashes the pipeline, even if the main test succeded.
added a simple " || true" to prevent failing.