### PR TITLE
feat(action): add graceful skip for macOS and Windows runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -1,0 +1,30 @@
+name: Test macOS Guard Rails 🍎
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test-macos-guard-rails:
+    name: Test macOS Guard Rails
+    runs-on: macos-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: ./.github/actions/this
+      - name: Test Nothing but Nix (should skip gracefully)
+        uses: ./.github/actions/this
+        with:
+          hatchet-protocol: cleave
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - name: Verify Nix Installation
+        run: |
+          nix --version
+          echo "✅ macOS workflow continued successfully after nothing-but-nix was skipped"
+          echo "Hello from macOS" | nix run "https://flakehub.com/f/NixOS/nixpkgs/*#neo-cowsay"

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -22,9 +22,6 @@ jobs:
         uses: ./.github/actions/this
         with:
           hatchet-protocol: cleave
-      - uses: DeterminateSystems/determinate-nix-action@main
-      - name: Verify Nix Installation
+      - name: Verify workflow continues after graceful skip
         run: |
-          nix --version
           echo "✅ Windows workflow continued successfully after nothing-but-nix was skipped"
-          echo "Hello from Windows" | nix run "https://flakehub.com/f/NixOS/nixpkgs/*#neo-cowsay"

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -1,0 +1,30 @@
+name: Test Windows Guard Rails 🪟
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows-guard-rails:
+    name: Test Windows Guard Rails
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: ./.github/actions/this
+      - name: Test Nothing but Nix (should skip gracefully)
+        uses: ./.github/actions/this
+        with:
+          hatchet-protocol: cleave
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - name: Verify Nix Installation
+        run: |
+          nix --version
+          echo "✅ Windows workflow continued successfully after nothing-but-nix was skipped"
+          echo "Hello from Windows" | nix run "https://flakehub.com/f/NixOS/nixpkgs/*#neo-cowsay"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ The action is production-ready and intended for use in GitHub Actions workflows 
 
 ## Technology Stack
 
-- **Platform**: GitHub Actions composite action (Ubuntu runners only)
+- **Platform**: GitHub Actions composite action (Ubuntu runners only; macOS and Windows runners gracefully skip)
 - **Shell**: Bash (embedded in `action.yml`)
 - **Filesystem**: BTRFS with RAID0, zstd compression, loop devices
 - **Tools**: `rmz` (Fast Unix Commands), Docker CLI, APT, snap
@@ -27,7 +27,9 @@ The action is production-ready and intended for use in GitHub Actions workflows 
 ├── LICENSE                 # MIT licence
 └── .github/
     └── workflows/
-        ├── test.yaml       # Integration tests with multiple Nix installers
+        ├── test.yaml       # Integration tests with multiple Nix installers (Ubuntu)
+        ├── test-macos.yaml # macOS guard rail validation tests
+        ├── test-windows.yaml # Windows guard rail validation tests
         └── debug.yaml      # Debugging workflow for space usage analysis
 ```
 
@@ -44,7 +46,7 @@ The action is production-ready and intended for use in GitHub Actions workflows 
 
 The action follows a specific execution order:
 
-1. **The Checks**: Validate environment (Ubuntu, GitHub Actions, no pre-existing `/nix`)
+1. **The Checks**: Validate environment (Ubuntu on Linux, macOS/Windows graceful skip, GitHub Actions, no pre-existing `/nix`)
 2. **The Hatchet Protocol**: Set purge level (0-3)
 3. **The Setup**: Download and install `rmz` binary (protocol level ≥2)
 4. **The Volume**: Create initial BTRFS volume from `/mnt` free space
@@ -190,6 +192,8 @@ Before submitting changes:
 ## Constraints
 
 - **Ubuntu only**: Action checks for Ubuntu via `lsb_release -is`
+- **macOS graceful skip**: Action detects macOS/Darwin runners and exits gracefully with a warning (workflow continues)
+- **Windows graceful skip**: Action detects Windows runners and exits gracefully with a warning (workflow continues)
 - **Pre-Nix only**: Must run before Nix installation (checks for `/nix` directory)
 - **GitHub Actions only**: Requires `$GITHUB_ACTIONS` environment variable
 - **BTRFS required**: Ubuntu runners include BTRFS tools by default

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ jobs:
 
 - Only supports official **Ubuntu** GitHub Actions runners
 - Must run **before** Nix is installed
+- **macOS/Darwin runners**: This action will gracefully skip with a warning if run on macOS. macOS runners already provide sufficient space for Nix and do not require this action
+- **Windows runners**: This action will gracefully skip with a warning if run on Windows. Windows runners have different filesystem layouts and constraints
 
 ## The Problem: Making Room for Nix to Thrive 🌱
 

--- a/action.yml
+++ b/action.yml
@@ -31,25 +31,46 @@ runs:
       id: environment-check
       shell: bash
       run: |
+        # Check for macOS/Darwin - warn but don't fail
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          echo "is_supported=false" >> $GITHUB_OUTPUT
+          echo "⚠️  Nothing but Nix is designed for Ubuntu runners only."
+          echo "ℹ️  macOS/Darwin runners do not require this action - they already provide sufficient space for Nix."
+          echo "ℹ️  This action will be skipped and your workflow will continue normally."
+          exit 0
+        fi
+
+        # Check for Windows - warn but don't fail
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          echo "is_supported=false" >> $GITHUB_OUTPUT
+          echo "⚠️  Nothing but Nix is designed for Ubuntu runners only."
+          echo "ℹ️  Windows runners do not require this action - they have different filesystem layouts and constraints."
+          echo "ℹ️  This action will be skipped and your workflow will continue normally."
+          exit 0
+        fi
+
+        # Check for Ubuntu on Linux runners
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           if [ "$(lsb_release -is)" != "Ubuntu" ]; then
             echo "is_supported=false" >> $GITHUB_OUTPUT
-            echo "This action only works on Ubuntu runners"
+            echo "❌ This action only works on Ubuntu runners"
             exit 1
           else
             echo "is_supported=true" >> $GITHUB_OUTPUT
           fi
         fi
 
+        # Check for GitHub Actions environment
         if [ -z "$GITHUB_ACTIONS" ]; then
           echo "is_supported=false" >> $GITHUB_OUTPUT
-          echo "This action only works on GitHub Actions runner"
+          echo "❌ This action only works on GitHub Actions runners"
           exit 1
         fi
 
+        # Check that Nix is not already installed
         if [ -d /nix ]; then
           echo "is_supported=false" >> $GITHUB_OUTPUT
-          echo "This action must be run before Nix is installed"
+          echo "❌ This action must be run before Nix is installed"
           exit 1
         else
           echo "is_supported=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Detect macOS/Darwin and Windows runners in environment check
- Exit with informative warnings instead of failing (exit 0)
- Add dedicated test workflows for macOS and Windows guard rails
- Update README and AGENTS documentation with platform support notes
- Improve error message emojis for better visibility

Closes #33 #39

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a graceful skip for macOS and Windows runners so the action exits with a warning and workflows continue. Ubuntu on Linux remains the only supported platform, with tests and docs updated.

- **New Features**
  - Detect macOS/Darwin and Windows runners and exit 0 with clear warnings.
  - Keep strict checks for Ubuntu, GitHub Actions environment, and pre-Nix install; improved error messages.
  - Add test-macos.yaml and test-windows.yaml to validate skip behavior.
  - Update README and AGENTS with platform support notes.

- **Dependencies**
  - Add Dependabot config for GitHub Actions (weekly).

<sup>Written for commit da69ce67432bda98dbba003148dadc69ed9d3b8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

