### PR TITLE
fix(volume): resolve TMPDIR permission conflict with multi-user installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ Some Nix installers or configurations expect the `/nix` directory to be writable
 
 When `nix-permission-edict` is set to `true`, the action will run `sudo chown -R "$(id --user)":"$(id --group)" /nix` after mounting `/nix`.
 
+### Configure Nix to use /nix/build
+
+This action creates `/nix/build` for Nix derivation builds to use the reclaimed space. Add `build-dir` to your Nix configuration:
+
+```yaml
+- uses: cachix/install-nix-action@v31
+  with:
+    extra_nix_config: |
+      build-dir = /nix/build
+```
+
+Or with DeterminateSystems:
+
+```yaml
+- uses: DeterminateSystems/nix-installer-action@main
+  with:
+    extra-conf: |
+      build-dir = /nix/build
+```
+
+This directs Nix to perform builds on the large BTRFS volume rather than the system's default temporary directory.
+
 ## Troubleshooting 🔍
 
 ### "No space left on device" during large builds

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         input_protocol="${{ inputs.hatchet-protocol }}"
         # Convert to lowercase for case-insensitive comparison
         input_protocol="$(tr '[:upper:]' '[:lower:]' <<< "$input_protocol")"
-        
+
         case "$input_protocol" in
           "holster")
             echo "🪓 Hatchet Protocol: Holster - Keep the hatchet sheathed, use space from /mnt (Level 0)"
@@ -107,7 +107,7 @@ runs:
       if: steps.environment-check.outputs.is_supported == 'true' && steps.set-hatchet-protocol.outputs.level > 1
       shell: bash
       run: |
-        ARCH=$(uname -m)          
+        ARCH=$(uname -m)
         if [[ "$ARCH" == "x86_64" ]]; then
           URL_ARCH="x86_64"
         elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
@@ -116,7 +116,7 @@ runs:
           echo "Unsupported architecture: $ARCH"
           exit 1
         fi
-        
+
         OS=$(uname -s)
         if [[ "$OS" == "Linux" ]]; then
           URL_OS="unknown-linux-gnu"
@@ -126,7 +126,7 @@ runs:
           echo "Unsupported OS: $OS"
           exit 1
         fi
-        
+
         DOWNLOAD_URL="https://github.com/SUPERCILEX/fuc/releases/download/3.0.1/${URL_ARCH}-${URL_OS}-rmz"
         curl -L -o rmz "$DOWNLOAD_URL"
         chmod +x rmz
@@ -160,7 +160,7 @@ runs:
           echo "❌ Failed to allocate disk image on /mnt"
           exit 1
         fi
-          
+
         # Create filesystem
         sudo mkfs.btrfs -L nix -d raid0 -m raid0 --nodiscard "${loop_dev}"
         sudo btrfs device scan
@@ -201,11 +201,11 @@ runs:
         cat > /tmp/expand_nix_volume.sh << 'EOF'
         #!/usr/bin/env bash
         set -e
-        
+
         protocol_level="${{ steps.set-hatchet-protocol.outputs.level }}"
         expansion_dir="${HOME}/.expansion"
         root_safe_haven="${{ inputs.root-safe-haven }}"
-        
+
         function add_expansion_disk() {
           # Check for additional free space after purging
           free_space=$(df -m --output=avail / | tail -n 1 | tr -d ' ')
@@ -221,11 +221,11 @@ runs:
             loop_num=${loop_dev##*/loop}
             if sudo fallocate -l ${disk_size}M "/disk${loop_num}.img"; then
               sudo losetup ${loop_dev} "/disk${loop_num}.img"
-              
+
               # Add the new device to the pool
               sudo btrfs device add --nodiscard ${loop_dev} /nix
               echo "Added expansion disk "/disk${loop_num}.img" (${loop_dev}, ${disk_size}MB) to /nix pool" > $expansion_dir/expansion_done
-              
+
               # Balance the filesystem to use the new space
               sudo btrfs balance start -dusage=50 /nix
               sudo btrfs filesystem show
@@ -329,7 +329,7 @@ runs:
           sudo apt-get -y clean
           echo "Cleanse apt complete" > $expansion_dir/apt_done
         fi
-        
+
         # Cleave
         if [[ "$protocol_level" -ge 2 ]]; then
           sudo rmz -f \
@@ -345,7 +345,7 @@ runs:
             /opt/mssql-tools
           echo "Cleave complete" > $expansion_dir/cleave_done
         fi
-        
+
         # Rampage
         if [[ "$protocol_level" -ge 3 ]]; then
           sudo rmz -f \
@@ -400,7 +400,7 @@ runs:
         post-run: |
           ls -ltr ${HOME}/.expansion/*_done || true
           all_disks=()
-  
+
           # Check for disks in /mnt directory
           mnt_disks=(/mnt/disk*.img)
           if [[ -e "${mnt_disks[0]}" ]]; then
@@ -411,8 +411,8 @@ runs:
           root_disks=(/disk*.img)
           if [[ -e "${root_disks[0]}" ]]; then
             all_disks+=("${root_disks[@]}")
-          fi        
-          
+          fi
+
           echo "Found ${#all_disks[@]} disk image(s):"
           for disk in "${all_disks[@]}"; do
             echo "- $disk ($(du -h "$disk" | cut -f1))"
@@ -425,4 +425,3 @@ runs:
           sudo btrfs filesystem show /nix
           echo "See actual allocation per device:"
           sudo btrfs device stats /nix
-          

--- a/action.yml
+++ b/action.yml
@@ -171,18 +171,18 @@ runs:
         sudo mount LABEL=nix /nix -o noatime,nobarrier,nodiscard,compress=zstd:1,space_cache=v2,commit=120
         sudo df -h
 
+        # Create /nix/build for Nix's build-dir setting
+        sudo mkdir -p /nix/build
+
         if [[ "${{ inputs.nix-permission-edict }}" == "true" ]]; then
           echo "Applying Nix Permission Edict: Granting user ownership of /nix"
           sudo chown -R "$(id --user)":"$(id --group)" /nix
         fi
 
-        # Create a tmp directory within /nix for Nix builds and set TMPDIR
-        # This ensures builds use the large BTRFS volume rather than depleted /mnt
-        TMPNIX="/nix/_tmp"
-        sudo mkdir -p "${TMPNIX}"
+        # Create TMPDIR on /mnt for Nix installer compatibility
+        TMPNIX="$(mktemp --directory --tmpdir=/mnt)"
         sudo chmod 1777 "${TMPNIX}"
         echo "TMPDIR=${TMPNIX}" >> $GITHUB_ENV
-        echo "TMPDIR set to ${TMPNIX} to use space on the /nix volume for builds."
 
         # Create a directory to store expansion state
         mkdir -p "${HOME}/.expansion"


### PR DESCRIPTION
TMPDIR on `/nix/_tmp` causes permission conflicts with multi-user Nix installers when `nix-permission-edict: true`.

The sequence:
1. Volume created, `chown -R user:group /nix` applied
2. `/nix/_tmp` created with sticky bit
3. Multi-user installer extracts to `$TMPDIR`, runs as root
4. `cd` into extracted directory fails with EPERM

This is a regression from #44, which reverted #25's fix for the same class of issue.

We can treat these as separate concerns:
- **TMPDIR**: `/mnt` (safe for installer, ~100-200MB footprint)
- **build-dir**: `/nix/build` (Nix's own mechanism for build space)

This PR modifies the action to create `/nix/build` and documents the `build-dir` configuration that uses it.

Add to your Nix installer config:

```yaml
build-dir = /nix/build
```

Example with cachix/install-nix-action:

```yaml
- uses: cachix/install-nix-action@v31
  with:
    extra_nix_config: |
      build-dir = /nix/build
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TMPDIR permission conflict with multi-user Nix installers by setting TMPDIR on /mnt and adds /nix/build for Nix builds. Installers no longer fail with EPERM, and builds use the large BTRFS volume.

- **Bug Fixes**
  - Set TMPDIR to a mktemp directory on /mnt with sticky bit. Prevents EPERM when the installer runs as root with nix-permission-edict: true.

- **Migration**
  - The action now creates /nix/build. Set build-dir = /nix/build in your Nix config (examples for Cachix and DeterminateSystems are in the README).

<sup>Written for commit 3789280774d06a750f8961bc8cbe68e056e41aad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



