### PR TITLE
fix(volume): add sudo for mktemp in /mnt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ runs:
         fi
 
         # Create TMPDIR on /mnt for Nix installer compatibility
-        TMPNIX="$(mktemp --directory --tmpdir=/mnt)"
+        TMPNIX="$(sudo mktemp --directory --tmpdir=/mnt)"
         sudo chmod 1777 "${TMPNIX}"
         echo "TMPDIR=${TMPNIX}" >> $GITHUB_ENV
 


### PR DESCRIPTION
Follow-up to #46.

The `/mnt` directory is root-owned on GitHub runners.

```diff
-TMPNIX="$(mktemp --directory --tmpdir=/mnt)"
+TMPNIX="$(sudo mktemp --directory --tmpdir=/mnt)"
```

Without this fix, the action fails with:
```
mktemp: failed to create directory via template '/mnt/tmp.XXXXXXXXXX': Permission denied
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run mktemp with sudo when creating TMPDIR in /mnt to fix “Permission denied” on GitHub runners. Ensures the action can set TMPDIR for the Nix installer without failing.

<sup>Written for commit cd91c27edba264e3216bd608bc34d9dea8a173cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

